### PR TITLE
Add support for Typst

### DIFF
--- a/src/cache/equationCache.tsx
+++ b/src/cache/equationCache.tsx
@@ -3,7 +3,7 @@ import { BaseCache } from '@/cache/baseCache';
 
 export class EquationCache extends BaseCache<EquationMatch> {
     protected parseMarkdown(markdown: string): EquationMatch[] {
-        return parseEquationsInMarkdown(markdown, true); 
+        return parseEquationsInMarkdown(markdown, true, this.plugin.settings.enableTypstMode); 
     }
     
     protected getCacheTypeName(): string {

--- a/src/commands/command_list.tsx
+++ b/src/commands/command_list.tsx
@@ -64,9 +64,9 @@ export default function registerCommands(plugin: EquationCitator) {
         callback: () => {
             const editor = plugin.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
             if (!editor) return;
-            const tagString = createEquationTagString("");
+            const tagString = createEquationTagString("", plugin.settings.enableTypstMode);
             // Move cursor inside the braces
-            insertTextWithCursorOffset(editor, tagString, 5);
+            insertTextWithCursorOffset(editor, tagString, plugin.settings.enableTypstMode ? 8 : 5);
         }
     })
 

--- a/src/func/autoNumber.tsx
+++ b/src/func/autoNumber.tsx
@@ -41,7 +41,7 @@ function restoreCursorPosition(editor: Editor, originalPos: EditorPosition): voi
 
 export async function autoNumberCurrentFileEquations(plugin: EquationCitator) {
     const { autoNumberType, autoNumberDepth, autoNumberDelimiter,
-        autoNumberNoHeadingPrefix, autoNumberGlobalPrefix: autoNumberPrefix, enableAutoNumberEquationsInQuotes: autoNumberEquationsInQuotes } = plugin.settings;
+        autoNumberNoHeadingPrefix, autoNumberGlobalPrefix: autoNumberPrefix, enableAutoNumberEquationsInQuotes: autoNumberEquationsInQuotes, enableTypstMode } = plugin.settings;
     const {
         deleteRepeatTagsInAutoNumber: deleteRepeatTags,
         deleteUnusedTagsInAutoNumber: deleteUnusedTags,
@@ -71,7 +71,8 @@ export async function autoNumberCurrentFileEquations(plugin: EquationCitator) {
                 autoNumberDelimiter,
                 autoNumberNoHeadingPrefix,
                 autoNumberPrefix,
-                autoNumberEquationsInQuotes
+                autoNumberEquationsInQuotes,
+                enableTypstMode,
             );
             tagMapping = tm;
             // rename tags by tagmapping
@@ -115,7 +116,7 @@ export function insertAutoNumberTag(plugin: EquationCitator): void {
     const cursorPos = editor.getCursor();
     const content = editor.getValue();
     const { autoNumberType, autoNumberDepth, autoNumberDelimiter,
-        autoNumberNoHeadingPrefix, autoNumberGlobalPrefix: autoNumberPrefix, enableAutoNumberEquationsInQuotes: autoNumberEquationsInQuotes } = plugin.settings;
+        autoNumberNoHeadingPrefix, autoNumberGlobalPrefix: autoNumberPrefix, enableAutoNumberEquationsInQuotes: autoNumberEquationsInQuotes, enableTypstMode } = plugin.settings;
 
     const autoNumberTag = getAutoNumberInCursor(
         content,
@@ -130,7 +131,7 @@ export function insertAutoNumberTag(plugin: EquationCitator): void {
         new Notice("Cursor is not in a valid equation block");
         return;
     }
-    const insertText = `\\tag{${autoNumberTag}}`;
+    const insertText = enableTypstMode ? `#label("${autoNumberTag}")` : `\\tag{${autoNumberTag}}`;
     insertTextWithCursorOffset(editor, insertText, insertText.length);
 }
 

--- a/src/handlers/rightButtonHandler.tsx
+++ b/src/handlers/rightButtonHandler.tsx
@@ -1,6 +1,6 @@
 import EquationCitator from "@/main"
 import { Menu, App, Editor, MarkdownView, MenuItem } from "obsidian"
-import { EditorSelectionInfo, tagSelectedField } from "@/views/citation_render";
+import { EditorSelectionInfo } from "@/views/citation_render";
 import { EditorState } from "@codemirror/state";
 import Debugger from "@/debug/debugger";
 import { TagRenameModal } from "@/ui/modals/tagRenameModal";
@@ -14,7 +14,7 @@ export function registerRightClickHandler(plugin: EquationCitator) {
             try {
                 // @ts-ignore
                 const state: EditorState = editor.cm?.state
-                tagInfo = state.field(tagSelectedField);  // get the selected tag  
+                tagInfo = state.field(plugin.tagSelectedField);  // get the selected tag  
             }
             catch (e) {
                 Debugger.error("Can't get selected tag: ", e);
@@ -38,7 +38,7 @@ export function registerRightClickHandler(plugin: EquationCitator) {
                         const modal = new TagRenameModal(plugin, tagInfo.tagContent, filePath);
                         modal.setEditor(editor);  // set the editor for the modal 
                         modal.onSubmit = (newName: string) => {
-                            const newTag = `\\tag{${newName}}`; 
+                            const newTag = plugin.settings.enableTypstMode ? `#label("${newName}")` : `\\tag{${newName}}`; 
                             const fromPos = editor.getCursor("from"); 
                             const toPos = editor.getCursor("to");
                             editor.replaceRange( 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import {
 import { cleanUpStyles, loadStyles, SettingsTabView } from "@/settings/SettingsTab";
 import { DEFAULT_SETTINGS } from "@/settings/defaultSettings";
 import { EquationCitatorSettings } from "@/settings/defaultSettings";
-import { Extension, Compartment } from '@codemirror/state';
+import { Extension, Compartment, StateField } from '@codemirror/state';
 import registerCommands from '@/commands/command_list';
 import registerRibbonButton from '@/ui/ribbon';
 import {
@@ -14,6 +14,7 @@ import {
     calloutCitationPostProcessor,
     createImageCaptionExtension,
     imageCaptionPostProcessor,
+    EditorSelectionInfo,
 } from '@/views/citation_render';
 import { EquationCache } from '@/cache/equationCache';
 import { CitationCache } from '@/cache/citationCache';
@@ -40,6 +41,7 @@ export default class EquationCitator extends Plugin {
     figureServices: FigureServices;
     calloutServices: CalloutServices;
     tagService: TagService;
+    tagSelectedField: StateField<EditorSelectionInfo>;
 
     // initialize caches
     public citationCache: CitationCache;   // citation cache instance

--- a/src/services/equation_services.tsx
+++ b/src/services/equation_services.tsx
@@ -151,7 +151,7 @@ export class EquationServices {
         }
 
         const editor = view.editor;
-        const tagString = createEquationTagString(tag);
+        const tagString = createEquationTagString(tag, this.plugin.settings.enableTypstMode);
 
         // Read the equation lines
         const equationLines: string[] = [];

--- a/src/settings/defaultSettings.tsx
+++ b/src/settings/defaultSettings.tsx
@@ -81,6 +81,7 @@ export interface EquationCitatorSettings {
     citationColorInPdf: string; // default citation color in PDF rendering
 
     // other settings  
+    enableTypstMode: boolean; // Enable compatibility with Typst syntax
     debugMode: boolean; // Optional setting for debug mode
     enableCiteWithCodeBlockInCallout: boolean; // Enable citation by inline code block in callout 
 
@@ -143,6 +144,7 @@ export const DEFAULT_SETTINGS: EquationCitatorSettings = {
 
     citationWidgetColor: ["#ffffff", "#f8f9fa", "#f5f6f7", "#e9ecef", "#dee2e6"],
     citationWidgetColorDark: ["#1e1e1e", "#2d2d2d", "#252525", "#3a3a3a", "#404040"],
+    enableTypstMode: false,
     debugMode: false, // debug mode is off by default (for set default, see debugger.tsx)
     // settings UI defaults
     settingsDisplayMode: "concise",
@@ -167,6 +169,7 @@ export const DEFAULT_SETTINGS: EquationCitatorSettings = {
         "autoNumberDelimiter",
         "enableAutoNumberEquationsInQuotes",
         "enableUpdateTagsInAutoNumber",
+        "enableTypstMode",
         "cacheUpdateTime",
         "cacheCleanTime",
         "citationWidgetColor",
@@ -497,6 +500,14 @@ export const SETTINGS_METADATA: Record<keyof EquationCitatorSettings, SettingsMe
         type: "color",
         renderCallback: (el, plugin) => {
             PdfExportSettingsTab.citationColorInPdf(el, plugin);
+        }
+    },
+    enableTypstMode: {
+        name: "Enable Typst Mode",
+        desc: "Enable compatibility with Typst syntax",
+        type: "boolean",
+        renderCallback: (el, plugin) => {
+            OtherSettingsTab.enableTypstMode(el, plugin);
         }
     },
     debugMode: {

--- a/src/settings/pages/OtherSettingsTab.tsx
+++ b/src/settings/pages/OtherSettingsTab.tsx
@@ -6,6 +6,20 @@ import { resetStyles, SettingsTabView } from "../SettingsTab";
 
 
 export const OtherSettingsTab = {
+    enableTypstMode(containerEl: HTMLElement, plugin: EquationCitator) {
+        const enableTypstModeSetting = new Setting(containerEl);
+        const { name, desc } = SETTINGS_METADATA.enableTypstMode;
+        enableTypstModeSetting.setName(name)
+            .setDesc(desc)
+            .addToggle((toggle) => {
+                toggle.setValue(plugin.settings.enableTypstMode);
+                toggle.onChange(async (value) => {
+                    plugin.settings.enableTypstMode = value;
+                    await plugin.saveSettings();
+                });
+            });
+    },
+
     debugMode(containerEl: HTMLElement, plugin: EquationCitator) {
         const { name, desc } = SETTINGS_METADATA.debugMode;
         const debugModeSetting = new Setting(containerEl);
@@ -71,6 +85,7 @@ export const OtherSettingsTab = {
 
 
 export function addOtherSettingsTab(containerEl: HTMLElement, plugin: EquationCitator, settingsTab: SettingsTabView) {
+    OtherSettingsTab.enableTypstMode(containerEl, plugin);
     OtherSettingsTab.debugMode(containerEl, plugin);
     OtherSettingsTab.resetSettings(containerEl, plugin, settingsTab);
     // ==================  Beta features settings ==========   

--- a/src/settings/settingsHelper.tsx
+++ b/src/settings/settingsHelper.tsx
@@ -97,6 +97,7 @@ export function getAllSettingsByCategory(): SettingsCategory[] {
             id: "other",
             title: "Other / Beta",
             settingKeys: [
+                "enableTypstMode",
                 "debugMode",
                 "enableCiteWithCodeBlockInCallout",
             ]

--- a/src/utils/core/auto_number_utils.tsx
+++ b/src/utils/core/auto_number_utils.tsx
@@ -210,7 +210,8 @@ export function autoNumberEquations(
     delimiter: string,
     noHeadingEquationPrefix: string,
     globalPrefix: string,
-    parseQuotes = false
+    parseQuotes = false,
+    enableTypstMode = false,
 ): AutoNumberProceedResult {
     const lines = content.split('\n');
     const headings = parseHeadingsInMarkdown(content);
@@ -242,12 +243,12 @@ export function autoNumberEquations(
         const tag = generateNextEquationTag(numberingState);
         if (equationBody.endsWith("\n")) {
             return {
-                eq: equationBody.slice(0, -1) + " " + createEquationTagString(tag) + "\n",
+                eq: equationBody.slice(0, -1) + " " + createEquationTagString(tag, enableTypstMode) + "\n",
                 tag: tag
             }
         } else {
             return {
-                eq: equationBody.trim() + " " + createEquationTagString(tag),
+                eq: equationBody.trim() + " " + createEquationTagString(tag, enableTypstMode),
                 tag: tag
             }
         }
@@ -290,7 +291,7 @@ export function autoNumberEquations(
             if (parseResult.isEquationBlockEnd) {
                 quotePrefix = parseResult.quoteDepth > 0 ? "> ".repeat(parseResult.quoteDepth) : "";
                 inEquationBlock = false;
-                const { content, tag: oldTag } = parseEquationTag(equationBuffer.join("\n"));
+                const { content, tag: oldTag } = parseEquationTag(equationBuffer.join("\n"), enableTypstMode);
                 const { eq, tag: newTag } = getTaggedEquation(content); 
                 addTagMapping(oldTag, newTag);
                 const fullEquationLines = `$$\n${eq}\n$$`.split("\n");
@@ -304,7 +305,7 @@ export function autoNumberEquations(
             const rawEquationContent = parseResult.singleLineEquationMatch[1].trim();
 
             // now not clear equation Content 
-            const { content, tag: oldTag } = parseEquationTag(rawEquationContent);
+            const { content, tag: oldTag } = parseEquationTag(rawEquationContent, enableTypstMode);
             const { eq, tag: newTag } = getTaggedEquation(content);
             // add tag mapping 
             addTagMapping(oldTag, newTag);
@@ -324,7 +325,7 @@ export function autoNumberEquations(
     // Handle unclosed equation blocks
     if (inEquationBlock && equationBuffer.length > 0) {
         const equation_raw = equationBuffer.join("\n");
-        const { content, tag: oldTag } = parseEquationTag(equation_raw);
+        const { content, tag: oldTag } = parseEquationTag(equation_raw, enableTypstMode);
         const { eq, tag: NewTag } = getTaggedEquation(content);
         
         // add tag mapping 

--- a/src/utils/parsers/equation_parser.tsx
+++ b/src/utils/parsers/equation_parser.tsx
@@ -40,10 +40,10 @@ export function isValidEquationPart(part: string, validDelimiters: string[]): bo
  * @param eqn : Raw equation block with $$ $$ bracket, also can have no $$ bracket 
  * @returns 
  */
-export function parseEquationTag(eqn: string): EquationParseResult {
+export function parseEquationTag(eqn: string, enableTypstMode = false): EquationParseResult {
     // Remove $$ if present 
     const contentWithTag = eqn.replace(/^\s*\$\$\s*/, "").replace(/\s*\$\$\s*$/, "").trim();
-    const pattern = createEquationTagRegex(false, null); 
+    const pattern = createEquationTagRegex(false, null, enableTypstMode); 
     const match = contentWithTag.match(pattern);   // only match first tag 
     // trim equations 
     const content = contentWithTag.replace(pattern, '').trim();
@@ -125,7 +125,7 @@ export function extractPrefixBeforeLastNumber(tag: string, validDelimiters: stri
  * @param markdown - The markdown content to parse
  * @returns Array of EquationMatch objects
  */
-export function parseEquationsInMarkdown(markdown: string, parseQuotes = true): EquationMatch[] {
+export function parseEquationsInMarkdown(markdown: string, parseQuotes = true, enableTypstMode = false): EquationMatch[] {
     if (!markdown.trim()) return [];
     const lines = markdown.split('\n');
 
@@ -149,7 +149,7 @@ export function parseEquationsInMarkdown(markdown: string, parseQuotes = true): 
             if (parseResult.isEquationBlockEnd) {
                 inEquationBlock = false;
                 const rawContent = equationBuffer.join('\n');
-                const { contentWithTag, content, tag } = parseEquationTag(rawContent);
+                const { contentWithTag, content, tag } = parseEquationTag(rawContent, enableTypstMode);
 
                 equations.push({
                     raw: rawContent,
@@ -168,7 +168,7 @@ export function parseEquationsInMarkdown(markdown: string, parseQuotes = true): 
         // Handle single-line equation blocks 
         if (parseResult.isSingleLineEquation && parseResult.singleLineEquationMatch) {
             const rawEquationContent = parseResult.singleLineEquationMatch[1].trim();
-            const { contentWithTag, content, tag } = parseEquationTag(rawEquationContent);
+            const { contentWithTag, content, tag } = parseEquationTag(rawEquationContent, enableTypstMode);
 
             equations.push({
                 raw: parseResult.cleanedLine.trim(),
@@ -195,7 +195,7 @@ export function parseEquationsInMarkdown(markdown: string, parseQuotes = true): 
     // Handle unclosed equation blocks
     if (inEquationBlock && equationBuffer.length > 0) {
         const rawContent = equationBuffer.join('\n');
-        const { contentWithTag, content, tag } = parseEquationTag(rawContent);
+        const { contentWithTag, content, tag } = parseEquationTag(rawContent, enableTypstMode);
 
         equations.push({
             raw: rawContent,
@@ -216,7 +216,7 @@ export function parseEquationsInMarkdown(markdown: string, parseQuotes = true): 
  * @param tag - The tag to search for (without \tag{} wrapper)
  * @returns The first EquationMatch with the matching tag, or undefined if not found
  */
-export function parseFirstEquationInMarkdown(markdown: string, tag: string): EquationMatch | undefined {
+export function parseFirstEquationInMarkdown(markdown: string, tag: string, enableTypstMode = false): EquationMatch | undefined {
     if (!markdown.trim() || !tag.trim()) return undefined;
 
     const lines = markdown.split('\n');
@@ -246,7 +246,7 @@ export function parseFirstEquationInMarkdown(markdown: string, tag: string): Equ
             if (parseResult.isEquationBlockEnd) {
                 inEquationBlock = false;
                 const rawContent = equationBuffer.join('\n');
-                const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawContent);
+                const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawContent, enableTypstMode);
 
                 // Check if this equation has the target tag
                 if (eqTag === tag) {
@@ -268,7 +268,7 @@ export function parseFirstEquationInMarkdown(markdown: string, tag: string): Equ
         // Handle single-line equation blcoks 
         if (parseResult.isSingleLineEquation && parseResult.singleLineEquationMatch) {
             const rawEquationContent = parseResult.singleLineEquationMatch[1].trim();
-            const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawEquationContent);
+            const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawEquationContent, enableTypstMode);
 
             // Check if this equation has the target tag
             if (eqTag === tag) {
@@ -298,7 +298,7 @@ export function parseFirstEquationInMarkdown(markdown: string, tag: string): Equ
     // Handle unclosed equation blocks
     if (inEquationBlock && equationBuffer.length > 0) {
         const rawContent = equationBuffer.join('\n');
-        const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawContent);
+        const { contentWithTag, content, tag: eqTag } = parseEquationTag(rawContent, enableTypstMode);
 
         // Check if this unclosed equation has the target tag
         if (eqTag === tag) {

--- a/src/utils/string_processing/regexp_utils.tsx
+++ b/src/utils/string_processing/regexp_utils.tsx
@@ -176,18 +176,25 @@ export function createCitationString(
 //////////////////////////// TAGS //////////////////////// 
 export function createEquationTagRegex(
     fullMatch = false,
-    tagName: string | null = null
+    tagName: string | null = null,
+    typst = false,
 ): RegExp {
     if (!tagName) {
-        return new RegExp(fullMatch ? /^\\tag\{([^}]*)\}$/ : /\\tag\{([^}]*)\}/);
+        return typst
+            ? new RegExp(fullMatch ? /^#label\("([^"]*)"\)$/ : /#label\("([^"]*)"\)/)
+            : new RegExp(fullMatch ? /^\\tag\{([^}]*)\}$/ : /\\tag\{([^}]*)\}/);
     }
     const escapedTagName = escapeRegExp(tagName);
-    return fullMatch ?
-        RegExp(`^\\\\tag\\{\\s*${tagName}\\s*\\}$`) :
-        RegExp(`\\\\tag\\{\\s*${escapedTagName}\\s*\\}`);
+    return typst
+        ? fullMatch
+            ? new RegExp(`^#label\\(\\s*"${escapedTagName}"\\s*\\)$`)
+            : new RegExp(`#label\\(\\s*"${escapedTagName}"\\s*\\)`)
+        : fullMatch
+            ? new RegExp(`^\\\\tag\\{\\s*${tagName}\\s*\\}$`)
+            : new RegExp(`\\\\tag\\{\\s*${escapedTagName}\\s*\\}`);
 }
 
-export function createEquationTagString(content: string): string {
-    const tagString = `\\tag{${content}}`;
+export function createEquationTagString(content: string, typst: boolean): string {
+    const tagString = typst ? `#label("${content}")` : `\\tag{${content}}`;
     return tagString;
 }

--- a/src/utils/workspace/equation_navigation.tsx
+++ b/src/utils/workspace/equation_navigation.tsx
@@ -28,7 +28,7 @@ export async function scrollToEquationByTag(
     }
 
     const md = await plugin.app.vault.cachedRead(file);
-    const match: EquationMatch | undefined = parseFirstEquationInMarkdown(md, tag);
+    const match: EquationMatch | undefined = parseFirstEquationInMarkdown(md, tag, plugin.settings.enableTypstMode);
     if (!match) {
         Debugger.log("Can't find equation with tag: " + tag + " in file: " + targetFilePath);
         return;


### PR DESCRIPTION
Thank you for the wonderful plugin!

Since I use [Typst](https://typst.app/), I added support for a Typst Mode.
This PR adds settings and processing for Typst, using `#label("content")` instead of `\tag{content}` for Typst equations.