### PR TITLE
use obsidian-typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"jest-environment-jsdom": "^30.0.5",
 		"jsdom": "^26.1.0",
 		"obsidian": "latest",
+		"obsidian-typings": "^4.63.0",
 		"ts-jest": "^29.4.0",
 		"ts-node": "^10.9.2",
 		"tslib": "2.4.0",

--- a/src/handlers/rightButtonHandler.tsx
+++ b/src/handlers/rightButtonHandler.tsx
@@ -12,9 +12,7 @@ export function registerRightClickHandler(plugin: EquationCitator) {
         app.workspace.on("editor-menu", (menu: Menu, editor: Editor, view: MarkdownView): void => {
             let tagInfo: EditorSelectionInfo;
             try {
-                // @ts-expect-error editor.cm exists
-
-                const state: EditorState = editor.cm?.state
+                const state: EditorState = editor.cm.state
                 tagInfo = state.field(plugin.tagSelectedField);  // get the selected tag  
             }
             catch (e) {

--- a/src/utils/workspace/drag_drop_event.tsx
+++ b/src/utils/workspace/drag_drop_event.tsx
@@ -37,13 +37,10 @@ export const dropCursorField = StateField.define<DecorationSet>({
 });
 
 export function clearDragCursor(targetView: MarkdownView): void {
-    const editor = targetView.editor;
-    // @ts-expect-error editor.cm exists
-    const cm6View = editor.cm;
-    if (!cm6View) return;
+    const cm = targetView.editor.cm;
 
     // Clear the drag cursor decoration
-    cm6View.dispatch({
+    cm.dispatch({
         effects: setDropCursorEffect.of(null)
     });
 }
@@ -52,15 +49,12 @@ export function getEditorDropLocation(
     editor: Editor,
     evt: DragEvent,
 ): { line: number, ch: number } | null {
-    // @ts-expect-error editor.cm exists
+    const cm = editor.cm;
 
-    const cm6View = editor.cm;
-    if (!cm6View) return null;
-
-    const pos = cm6View.posAtCoords({ x: evt.clientX, y: evt.clientY });
+    const pos = cm.posAtCoords({ x: evt.clientX, y: evt.clientY });
     if (pos === null) return null;
 
-    const lineInfo: Line = cm6View.state.doc.lineAt(pos); 
+    const lineInfo: Line = cm.state.doc.lineAt(pos);
     const line = lineInfo.number - 1; // CM6 uses 1-based line numbers
     const ch = pos - lineInfo.from;
 
@@ -72,17 +66,13 @@ export function drawCursorAtDragPosition(
     evt: DragEvent,
     targetView: MarkdownView
 ): void {
-    const editor = targetView.editor;
-    // @ts-expect-error editor.cm exists
+    const cm = targetView.editor.cm;
 
-    const cm6View = editor.cm;
-    if (!cm6View) return;
-
-    const pos = cm6View.posAtCoords({ x: evt.clientX, y: evt.clientY });
+    const pos = cm.posAtCoords({ x: evt.clientX, y: evt.clientY });
     if (pos === null || pos === lastDropPos) return;
 
     lastDropPos = pos;
-    cm6View.dispatch({
+    cm.dispatch({
         // use a common effect for the drag effect to render. 
         effects: setDropCursorEffect.of(pos)
     });

--- a/src/utils/workspace/workspace_utils.tsx
+++ b/src/utils/workspace/workspace_utils.tsx
@@ -1,4 +1,4 @@
-import { App, WorkspaceLeaf, MarkdownView, editorInfoField } from "obsidian";
+import { App, WorkspaceLeaf, MarkdownView, editorInfoField, editorLivePreviewField } from "obsidian";
 import { EditorView } from "@codemirror/view";
 
 export function getLeafByElement(app: App, el: HTMLElement) : WorkspaceLeaf | null { 
@@ -14,9 +14,5 @@ export function getLeafByElement(app: App, el: HTMLElement) : WorkspaceLeaf | nu
 }
 
 export function isSourceMode(view: EditorView): boolean {
-    const mdView = view.state.field(editorInfoField, false) as MarkdownView | undefined;
-    const currentMode = mdView?.currentMode;
-    // @ts-expect-error editor.cm exists
-
-    return currentMode?.sourceMode ? true : false;
+    return !view.state.field(editorLivePreviewField);
 }

--- a/src/views/auto_complete_suggest.tsx
+++ b/src/views/auto_complete_suggest.tsx
@@ -160,12 +160,9 @@ export class AutoCompleteSuggest extends EditorSuggest<RenderedEquation> {
         // judge if it's source mode or not 
         const mdView = this.plugin.app.workspace.activeEditor?.editor;
         if (!mdView) return null;
-
-        // @ts-expect-error editor.cm exists
  
-        const editorView: EditorView = editor.cm;
-        if (!editorView) return null;
-        if (isSourceMode(editorView) && !enableCitationInSourceMode) {
+        const cm = editor.cm;
+        if (isSourceMode(cm) && !enableCitationInSourceMode) {
             return null; // do not suggest in source mode if not enabled in settings
         }
 

--- a/src/views/widgets/citation_render.tsx
+++ b/src/views/widgets/citation_render.tsx
@@ -481,8 +481,6 @@ async function showReadingModeFigurePopover(
 
     let popover: FigureCitationPopover | null = new FigureCitationPopover(
         plugin,
-        // @ts-expect-error editor.cm exists
-
         activeLeaf,
         citationEl,
         figures,
@@ -533,8 +531,6 @@ async function showReadingModeCalloutPopover(
 
     let popover: CalloutCitationPopover | null = new CalloutCitationPopover(
         plugin,
-        // @ts-expect-error editor.cm exists
-
         activeLeaf,
         citationEl,
         prefix,
@@ -614,8 +610,6 @@ async function showReadingModePopover(
 
     let popover: CitationPopover | null = new CitationPopover(
         plugin,
-        // @ts-expect-error editor.cm exists
-
         activeLeaf,
         citationEl,
         equations,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["node"],
+    "types": ["node", "obsidian-typings"],
     "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": true, 
@@ -14,12 +14,7 @@
     "isolatedModules": true,
     "strictNullChecks": true,
     "esModuleInterop": true, 
-    "lib": [
-      "DOM",
-      "ES5",
-      "ES6",
-      "ES7"
-    ],
+    "lib": ["ESNext", "DOM"],
     "paths": {
       "@/*": ["src/*"],
     }


### PR DESCRIPTION
[obsidian-typings](https://github.com/Fevol/obsidian-typings) is an unofficial Obsidian API.
However, it is still actively maintained by many developers and provides safer typings.

Also, according to obsidian-typings, currentMode.sourceMode is deprecated.
Therefore I changed to use `view.state.field(editorLivePreviewField)`.