### PR TITLE
fix critical #157 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,12 @@ Settings Updates :
 ### Version 1.3.4
 Version 1.3.4 - Multi-Platform Support, bug fixes and improvements.
 
+---
+
+Breaking Update Changes : 
+- Now we use a configurable math renderer, we changed default renderer to a slow one for better stability, but you can still use the fast one by `Settings > Display (Categorical) > Equation Panel > Use fast math renderer in equation panel`.
+
+----- 
 
 ✈️ Full-Cross-Platform Support :
 - [x] Test this plugin on Linux and Mac platform (thanks to my friend @Tiddlefox)
@@ -374,6 +380,7 @@ Version 1.3.4 - Multi-Platform Support, bug fixes and improvements.
 - [x] Add `data-line` reassign mechanism for `viewStateEqual` case. So the line-number information still refresh correctly when editing at middle at pure-text files. 
 - [x] fix [issue #151](https://github.com/FRIEDparrot/obsidian-equation-citator/issues/151), add css to make up for style change in `obsidian 1.12.4` 
 - [x] Fix all new sonar issues for better code quality. 
+- [x] (Critical) Fix [critical #157](https://github.com/FRIEDparrot/obsidian-equation-citator/issues/157), by default we use slow but more stable obsidian build-in renderer. But `MathJax` is still available by `Settings > Display (Categorical) > Equation Panel > Use fast math renderer in equation panel`. 
 
 📖 Documentation : 
 - [x] Add settings usage | equation panel button usage | rich auto complete mode in tutorial.

--- a/src/settings/defaultSettings.tsx
+++ b/src/settings/defaultSettings.tsx
@@ -109,6 +109,7 @@ export interface EquationCitatorSettings {
     typstBoxSymbol: string; // Override symbol for boxed equation in typst mode, default to box
     equationManagePanelEnableRenderHeadingsOnly: boolean;
     equationWidgetRightClickCopyType: "full" | "noTag" | "eq", // right click to copy full content or only equation code in equation panel.
+    useFastMathRenderer: boolean; // whether to use fast but less reliable math rendering method in equation panel, default to false
 
     // settings UI
     settingsDisplayMode: "categorical" | "concise" | "list"; // settings tab display mode
@@ -203,6 +204,7 @@ export const DEFAULT_SETTINGS: EquationCitatorSettings = {
         "enableAutoNumberEquationsInQuotes",
         "enableUpdateTagsInAutoNumber",
         "enableTypstMode",
+        "useFastMathRenderer",
         "cacheUpdateTime",
         "cacheCleanTime",
         "debugMode",
@@ -216,6 +218,7 @@ export const DEFAULT_SETTINGS: EquationCitatorSettings = {
     equationManagePanelFilterBoxedEquation: false,
     skipFirstlineInBoxedFilter: false, 
     equationWidgetRightClickCopyType: "full",
+    useFastMathRenderer: false, // default to false, use reliable math rendering method in equation panel
 };
 
 export const SETTINGS_METADATA: Record<keyof EquationCitatorSettings, SettingsMetadata> = {
@@ -690,5 +693,13 @@ export const SETTINGS_METADATA: Record<keyof EquationCitatorSettings, SettingsMe
         renderCallback: (el, plugin) => {
             EquationPanelSettingsTab.equationWidgetRightClickCopyType(el, plugin);
         }
-    }
+    },
+    useFastMathRenderer: {
+        name: "Use fast math renderer in equation panel",
+        desc: "Whether to use a fast math rendering for equations. Fast renderer can significantly speed up the load of equations, but may cause rendering issues at first, this will often be resolved after scrolling",
+        type: "boolean",
+        renderCallback: (el, plugin) => {
+            EquationPanelSettingsTab.useFastMathRenderer(el, plugin);
+        }
+    },
 }

--- a/src/settings/pages/equationPanelSettingsTab.tsx
+++ b/src/settings/pages/equationPanelSettingsTab.tsx
@@ -133,12 +133,25 @@ export const EquationPanelSettingsTab = {
                 dropdown.addOption("noTag", "Without tags");
                 dropdown.addOption("eq", "Without tags and braces");
                 dropdown.setValue(plugin.settings.equationWidgetRightClickCopyType);
-                dropdown.onChange(async (value) => { 
+                dropdown.onChange(async (value) => {
                     plugin.settings.equationWidgetRightClickCopyType = value as "full" | "noTag" | "eq";
                     await plugin.saveSettings();
                 });
-        });
-    }
+            });
+    },
+    useFastMathRenderer(containerEl: HTMLElement, plugin: EquationCitator) {
+        const { name, desc } = SETTINGS_METADATA.useFastMathRenderer;
+        new Setting(containerEl)
+            .setName(name)
+            .setDesc(desc)
+            .addToggle((toggle) => {
+                toggle.setValue(plugin.settings.useFastMathRenderer);
+                toggle.onChange(async (value) => {
+                    plugin.settings.useFastMathRenderer = value;
+                    await plugin.saveSettings();
+                });
+            });
+    },
 };
 
 /**
@@ -156,4 +169,5 @@ export function addEquationPanelSettingsTab(containerEl: HTMLElement, plugin: Eq
     EquationPanelSettingsTab.equationManagePanelLazyUpdateTime(containerEl, plugin);
     EquationPanelSettingsTab.equationManagePanelFileCheckInterval(containerEl, plugin);
     EquationPanelSettingsTab.equationWidgetRightClickCopyType(containerEl, plugin);
+    EquationPanelSettingsTab.useFastMathRenderer(containerEl, plugin);
 }

--- a/src/settings/settingsHelper.tsx
+++ b/src/settings/settingsHelper.tsx
@@ -79,6 +79,7 @@ export function getAllSettingsByCategory(): SettingsCategory[] {
                 "equationManagePanelFilterBoxedEquation",
                 "skipFirstlineInBoxedFilter",
                 "equationWidgetRightClickCopyType",
+                "useFastMathRenderer",
             ]
         },
         {

--- a/src/styles/panels.scss
+++ b/src/styles/panels.scss
@@ -328,14 +328,18 @@
 }
 
 .ec-equation-math {
+    display: block; // Ensure block layout for proper rendering
     font-size: 14px;
     overflow-x: auto;
+    min-height: 1px; // Force layout calculation
+    flex-shrink: 0; // Prevent flex container from collapsing
 
     /* Style the rendered math */
     .math {
         font-size: 1em;
     }
     
+    // Ensure MathJax output is visible and properly laid out
     mjx-container {
         margin: 0;
     }

--- a/src/ui/panels/equationManagePanel/mainPanel.tsx
+++ b/src/ui/panels/equationManagePanel/mainPanel.tsx
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf, MarkdownView, TFile, loadMathJax, normalizePath, Platform, Menu, MarkdownRenderer } from "obsidian";
+import { ItemView, WorkspaceLeaf, MarkdownView, TFile, loadMathJax, normalizePath, Platform, Menu, MarkdownRenderer, renderMath, finishRenderMath } from "obsidian";
 import EquationCitator from "@/main";
 import { EquationMatch } from "@/utils/parsers/equation_parser";
 import { ImageMatch } from "@/utils/parsers/image_parser";
@@ -9,7 +9,6 @@ import Debugger from "@/debug/debugger";
 
 import { scrollToEquationByTag } from "@/utils/workspace/equation_navigation";
 import { isMarkdownFilePath } from "@/utils/misc/fileProcessor";
-import { forceMathRefresh } from "@/utils/misc/mathjax_utils";
 import { copyEquationToClipboard } from "@/utils/misc/equation_copy";
 
 import {
@@ -469,8 +468,16 @@ export class EquationArrangePanel extends ItemView {
 
         // Render the equation
         if (!window.MathJax) await loadMathJax();
-        mathDiv.replaceChildren(window.MathJax!.tex2chtml(equation.content, { display: true }));
-        await forceMathRefresh(mathDiv, this.viewPanel);
+        
+        if (this.plugin.settings.useFastMathRenderer) {
+            // Fast method: Direct conversion 
+            mathDiv.replaceChildren(window.MathJax!.tex2chtml(equation.content, { display: true }));
+        } else {
+            // Reliable method: Use typesetPromise for proper rendering
+            const  rendered = renderMath(equation.content, true);
+            mathDiv.replaceChildren(rendered);
+            await finishRenderMath();
+        }
 
         // Add click handler to jump to equation in the editor
         // Ctrl/Cmd + double click always creates new panel on right

--- a/src/views/popovers/citation_popover.tsx
+++ b/src/views/popovers/citation_popover.tsx
@@ -8,6 +8,8 @@ import {
     HoverParent,
     MarkdownView,
     Menu,
+    renderMath,
+    finishRenderMath,
 } from "obsidian";
 import Debugger from "@/debug/debugger";
 
@@ -22,7 +24,6 @@ import { getLeafByElement } from "@/utils/workspace/workspace_utils";
 import { openFileAndScrollToEquation } from "@/utils/workspace/equation_navigation";
 import { parseEquationTag } from "@/utils/parsers/equation_parser";
 import { WidgetSizeManager } from "@/settings/styleManagers/widgetSizeManager";
-import { forceMathRefresh } from "@/utils/misc/mathjax_utils";
 import { copyEquationToClipboard } from "@/utils/misc/equation_copy";
 
 /**
@@ -155,8 +156,17 @@ export async function renderEquationWrapper(
     // Render the equation
     if (!window.MathJax) await loadMathJax();
     const eqTag = parseEquationTag(eq.md);
-    equationDiv.replaceChildren(window.MathJax!.tex2chtml(eqTag.content, { display: true }));
-    await forceMathRefresh(equationDiv);
+    
+    // render the math equation
+    if (plugin.settings.useFastMathRenderer) {
+        // Fast method: Direct conversion
+        equationDiv.replaceChildren(window.MathJax!.tex2chtml(eqTag.content, { display: true }));
+    } else {
+        const rendered = renderMath(eqTag.content, true);
+        equationDiv.replaceChildren(rendered);
+        await finishRenderMath();
+    }
+    
     // Add click effects to each equation
     addClickEffects(equationWrapper);
     if (addLinkJump) {

--- a/tutorials/Quick Start.md
+++ b/tutorials/Quick Start.md
@@ -279,10 +279,13 @@ You can open the equation mange panel by :
 - Command palette: `Open Equations Manage Panel`
 - Toolbar icon (if enabled) 
 
-### 2) How to use this panel   
+### 2) Math Renderer Settings
+By default, the panel uses a **reliable rendering method** that ensures equations display correctly. If you have many equations and experience slow loading, enable **"Use fast math renderer"** in settings (**Settings > Display (Categorical) > Equation Panel > Use fast math renderer in equation panel**). The fast renderer may show empty containers initially, but they'll appear correctly after scrolling.
+
+### 3) How to use this panel
 Equation Manage panel is one of the most powerful feature of v1.3.0, it allows you to cite and search equation fast and easy, **No need to scroll or remember syntax or equation numbers!** 
 
-#### 2.1 Usage of buttons on panel toolbar :
+#### 3.1 Usage of buttons on panel toolbar :
 
 ![Tool bar Image](panel_toolbars.png)
 
@@ -303,13 +306,13 @@ The subpanel includes :
     - 1.Show only tagged equations/figures/callouts. (This works for all types of content)
     - 2. show only boxed equations. (This only works for equations)
 
-#### 2.2 Drag and Drop Citations 
+#### 3.2 Drag and Drop Citations 
 1. **Drag** the item from the panel, **Drop** it into your text where you want the citation, the properly formatted `\ref{}` citation is automatically inserted
 2. If you have **multiple files opened in editor**, you can also **drag equations to other files**. The plugin will **automatically create footnotes for cross-file citations**.
 3. For callouts in panel, we don't support drag-cite callouts without correct tags (since it will break original prefix), please add tag for it manually.
 
 
-#### 2.3 Special Filters
+#### 3.3 Special Filters
 
 Filters are very useful features for you to manage important equations. Currently we provide 2 filters :
 


### PR DESCRIPTION
## Summary by Sourcery

Make math rendering in the equation panel configurable and default to a slower but more stable renderer to address rendering issues, while retaining the previous fast MathJax-based option.

New Features:
- Add a `useFastMathRenderer` setting to toggle between fast MathJax rendering and a more reliable built-in renderer for equations in the panel and citation popover.

Bug Fixes:
- Resolve critical rendering issues in the equation panel by switching the default renderer to the more stable built-in math renderer and adjusting styles for correct layout.

Enhancements:
- Expose the new renderer option in the settings UI and surface it in the quick start tutorial and changelog for better discoverability.

Documentation:
- Update the Quick Start tutorial and changelog to explain the new math renderer behavior, configuration option, and associated breaking change.