### PR TITLE
refactored "setTimeout" to activewindow.setTimeout

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,8 @@ export default defineConfig([
             parserOptions: { project: "./tsconfig.json" },
             globals: {
                 ...globals.browser,
-                ...globals.node,
+                activeWindow: "readonly",
+                activeDocument: "readonly",
             },
         },
         plugins: {

--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -419,7 +419,7 @@ export class SettingsTabView extends PluginSettingTab {
                     button.setIcon("reset");
                     button.onClick(async () => {
                         new Notice("Restoring settings...");
-                        await new Promise((resolve) => setTimeout(resolve, 200));
+                        await new Promise((resolve) => activeWindow.setTimeout(resolve, 200));
                         this.plugin.settings = { ...DEFAULT_SETTINGS };
                         resetStyles();
                         await this.plugin.saveSettings();

--- a/src/settings/pages/otherSettingsTab.tsx
+++ b/src/settings/pages/otherSettingsTab.tsx
@@ -70,7 +70,7 @@ export const OtherSettingsTab = {
                     new Notice("Restoring settings...");
                     
                     // Add a small delay to show the animation
-                    await new Promise(resolve => setTimeout(resolve, 200));
+                    await new Promise(resolve => activeWindow.setTimeout(resolve, 200));
                     
                     plugin.settings = { ...DEFAULT_SETTINGS };
                     resetStyles(); // reset styles

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,11 +1,6 @@
 import "obsidian";
 import type { EditorView } from "@codemirror/view";
 
-declare global {
-    const activeWindow: Window;
-    const activeDocument: Document;
-}
-
 declare module "obsidian" {
     interface Editor {
         cm: EditorView;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,11 @@
 import "obsidian";
 import type { EditorView } from "@codemirror/view";
 
+declare global {
+    const activeWindow: Window;
+    const activeDocument: Document;
+}
+
 declare module "obsidian" {
     interface Editor {
         cm: EditorView;

--- a/src/ui/panels/equationManagePanel/mainPanel.tsx
+++ b/src/ui/panels/equationManagePanel/mainPanel.tsx
@@ -509,7 +509,7 @@ export class EquationArrangePanel extends ItemView {
 
                     // Scroll to the equation after layout is ready
                     this.app.workspace.onLayoutReady(() => {
-                        setTimeout(() => {
+                        activeWindow.setTimeout(() => {
                             if (equation.tag) {
                                 void scrollToEquationByTag(this.plugin, equation.tag, currentFile.path);
                             }
@@ -607,7 +607,7 @@ export class EquationArrangePanel extends ItemView {
 
                     // Scroll to the figure after layout is ready
                     this.app.workspace.onLayoutReady(() => {
-                        setTimeout(() => {
+                        activeWindow.setTimeout(() => {
                             this.jumpToLine(figure.line).then().catch(console.error);
                         }, 50);
                     });
@@ -685,7 +685,7 @@ export class EquationArrangePanel extends ItemView {
 
                     // Scroll to the callout after layout is ready
                     this.app.workspace.onLayoutReady(() => {
-                        setTimeout(() => {
+                        activeWindow.setTimeout(() => {
                             this.jumpToLine(callout.lineStart).then().catch(console.error);
                         }, 50);
                     });

--- a/src/utils/workspace/equation_navigation.tsx
+++ b/src/utils/workspace/equation_navigation.tsx
@@ -56,7 +56,7 @@ export async function scrollToEquationByTag(
             editor.scrollIntoView(scrollRange, true);
         } else if (retries > 0) {
             Debugger.log(`Line count ${editor.lineCount()} is less than lineStart ${lineStart}, retrying...`);
-            setTimeout(() => {
+            activeWindow.setTimeout(() => {
                 tryScroll(retries - 1);
             }, 350);
         } else if (retries === 0) {
@@ -139,7 +139,7 @@ export async function openFileAndScrollToEquation(
     // Scroll to the equation after layout is ready
     plugin.app.workspace.onLayoutReady(() => {
         // Ensure the layout is ready before scrolling to the tag
-        setTimeout(() => {
+        activeWindow.setTimeout(() => {
             scrollToEquationByTag(plugin, tag, normalizedSourcePath).then().catch(console.error);
         }, 50);
     });

--- a/src/views/popovers/callout_citation_popover.tsx
+++ b/src/views/popovers/callout_citation_popover.tsx
@@ -224,7 +224,7 @@ function addClickEffects(calloutWrapper: HTMLElement): void {
 
     calloutWrapper.addEventListener("click", () => {
         calloutWrapper.addClass("em-callout-clicked");
-        setTimeout(() => {
+        activeWindow.setTimeout(() => {
             calloutWrapper.removeClass("em-callout-clicked");
         }, 300);
     });
@@ -321,7 +321,7 @@ async function openFileAndScrollToCallout(
     }
 
     // Scroll to the callout
-    setTimeout(() => {
+    activeWindow.setTimeout(() => {
         const view = targetLeaf.view;
         if (view instanceof MarkdownView && view.editor) {
             const editor = view.editor;

--- a/src/views/popovers/figure_citation_popover.tsx
+++ b/src/views/popovers/figure_citation_popover.tsx
@@ -279,7 +279,7 @@ function addClickEffects(figureWrapper: HTMLElement): void {
 
     figureWrapper.addEventListener("click", () => {
         figureWrapper.addClass("em-figure-clicked");
-        setTimeout(() => {
+        activeWindow.setTimeout(() => {
             figureWrapper.removeClass("em-figure-clicked");
         }, 300);
     });
@@ -373,7 +373,7 @@ async function openFileAndScrollToFigure(
     }
 
     // Scroll to the figure
-    setTimeout(() => {
+    activeWindow.setTimeout(() => {
         const view = targetLeaf.view;
         if (view instanceof MarkdownView && view.editor) {
             const editor = view.editor;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Standardize timeout scheduling on activeWindow.setTimeout instead of the global setTimeout in equation navigation, citation popovers, and settings-related UI interactions.