### PR TITLE
updated README for correct docs link

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -12,7 +12,7 @@
   <img src="https://sonarcloud.io/api/project_badges/measure?project=FRIEDparrot_obsidian-equation-citator&metric=alert_status" alt="Quality Gate">
 </span></div></center>
 
-<center><a href="/projects/obsidian-equation-citator/en/index.html">English </a> | <a href="/projects/obsidian-equation-citator/zh-CN/index.html">简体中文</a></center>
+<center><a href="https://friedparrot.github.io/projects/obsidian-equation-citator/en/index.html">English </a> | <a href="https://friedparrot.github.io/projects/obsidian-equation-citator/zh-CN/index.html">简体中文</a></center>
 
 <center><h4>强大、便捷且优雅的学术引用工具</h4></center>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img src="https://sonarcloud.io/api/project_badges/measure?project=FRIEDparrot_obsidian-equation-citator&metric=alert_status" alt="Quality Gate">
 </span></div></center>
 
-<center><a href="/projects/obsidian-equation-citator/en/index.html">English </a> | <a href="/projects/obsidian-equation-citator/zh-CN/index.html">简体中文</a></center>
+<center><a href="https://friedparrot.github.io/projects/obsidian-equation-citator/en/index.html">English </a> | <a href="https://friedparrot.github.io/projects/obsidian-equation-citator/zh-CN/index.html">简体中文</a></center>
 
 <center><h4>A Powerful, Convenient & Elegant Academic Tool for Citation</h4></center>
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix README and README-zh-CN language selector links to use the public GitHub Pages documentation URLs.