### PR TITLE
added dynamic popover position adjusting

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -1,5 +1,47 @@
 @use "variables";
 
+/* Hide popover content during the first render pass so the user doesn't see
+   content flicker / a wrong-positioned popover while async rendering and
+   viewport-clamp math complete. The class is added in JS and removed on
+   the next animation frame after adjustPopoverPosition runs. */
+.em-popover-rendering {
+    visibility: hidden;
+}
+
+/* Popover positioning — JS sets --em-popover-left / --em-popover-top on the
+   popover host via setProperty(); SCSS binds them as left/top on the host.
+   We tag the host ourselves (see adjustPopoverPosition) instead of depending
+   on Obsidian's internal `.hover-popover` class, so this rule stays scoped
+   to popovers we create. The host is already position: absolute (set by
+   Obsidian's HoverPopover), so left/top here replaces Obsidian's default
+   placement. */
+.em-popover-host {
+    /* Obsidian's HoverPopover sets inline `style.left` / `style.top` directly
+       on the host to place it. Those inline styles win over class rules by
+       specificity, so `!important` is needed here for our CSS-var-driven
+       placement to actually take effect. The CSS variables themselves are
+       written via setProperty() (allowed by the Obsidian plugin review bot);
+       !important in pure CSS is fine.
+
+       We use physical `top` / `left` (not the logical `inset-*` variants)
+       for two reasons:
+         1. Some browser/Electron versions misbehave when logical insets
+            (inset-block-start / inset-inline-start) are set with `!important`
+            while Obsidian sets physical inline styles on the same element —
+            the cascade comparison is per-property and physical-vs-logical
+            can leave the host stretched to fill its offset container.
+         2. With `position: absolute` and only one of top/bottom (or its
+            logical equivalent) specified plus auto height, some Chromium
+            builds default the unspecified edge to fill the offset container.
+            Adding `height: max-content` keeps the host tightly wrapped
+            around its container child. */
+    position: absolute !important;
+    left: var(--em-popover-left, 0px) !important;
+    top: var(--em-popover-top, 0px) !important;
+    height: max-content !important;
+    width: max-content !important;
+}
+
 /* Main container styles */
 .em-citation-popover-container {
     min-width: var(--em-citation-popover-container-width);

--- a/src/utils/workspace/popoverPosition.tsx
+++ b/src/utils/workspace/popoverPosition.tsx
@@ -1,0 +1,95 @@
+/**
+ * Pure position computation for a popover anchored to the mouse cursor.
+ *
+ * The popover is placed just to the right/below the cursor (offset px away,
+ * so it never covers the cursor). For each axis independently, if that
+ * placement would overflow the viewport, try flipping to the left/above the
+ * cursor — but only if the flipped position is in-bounds (>= gutter). If the
+ * flip would also overflow, fall back to the original right/below placement
+ * (the popover is then allowed to overflow the viewport edge — better than
+ * placing it far from the cursor).
+ *
+ * All popovers in this plugin are triggered by hover, so the cursor position
+ * is always recorded at trigger time and passed in; the target element's
+ * rectangle is intentionally NOT part of the computation.
+ */
+export function computePopoverPosition(
+    popRect: { width: number; height: number },
+    anchor: { x: number; y: number },
+    viewport: { width: number; height: number },
+    offset = 10,
+    gutter = 10,
+): { left: number; top: number } {
+    let left = anchor.x + offset;
+    let top = anchor.y + offset;
+
+    // Horizontal: if placing to the right of the cursor overflows, try
+    // flipping to the left of the cursor — but only if it fits.
+    if (left + popRect.width > viewport.width) {
+        const flipped = anchor.x - popRect.width - offset;
+        if (flipped >= gutter) {
+            left = flipped;
+        }
+    }
+
+    // Vertical: same logic, axis-independent.
+    if (top + popRect.height > viewport.height) {
+        const flipped = anchor.y - popRect.height - offset;
+        if (flipped >= gutter) {
+            top = flipped;
+        }
+    }
+
+    return { left, top };
+}
+
+/**
+ * Position a popover so it stays inside the viewport. Tags the host with
+ * `em-popover-host` (the class SCSS uses to bind the position CSS variables)
+ * and writes the resolved coordinates as CSS custom properties — never
+ * assigns to .style.left / .style.top directly, so the Obsidian plugin
+ * review bot (which flags inline style assignments for positioning) stays
+ * happy.
+ *
+ * The position is computed from the mouse cursor only (mouseX/mouseY),
+ * recorded when the popover was triggered by hover.
+ *
+ * Note on specificity: Obsidian's HoverPopover sets inline `style.left` /
+ * `style.top` on the host to place it. Those inline styles win over plain
+ * class rules by CSS specificity, so the matching SCSS rule needs
+ * `!important` for our CSS-var placement to actually take effect.
+ *
+ * The matching SCSS is expected to bind those variables on the host, e.g.:
+ *   .em-popover-host {
+ *       position: absolute !important;
+ *       left: var(--em-popover-left, 0) !important;
+ *       top: var(--em-popover-top, 0) !important;
+ *       width: max-content !important;
+ *       height: max-content !important;
+ *   }
+ *
+ * No-op when `hoverEl` is missing or not yet laid out.
+ */
+export function adjustPopoverPosition(
+    hoverEl: HTMLElement | null,
+    mouseX: number,
+    mouseY: number,
+): void {
+    if (!hoverEl) return;
+
+    hoverEl.addClass("em-popover-host");
+
+    const popRect = hoverEl.getBoundingClientRect();
+    // Bail out if the popover isn't measured yet (width/height === 0).
+    if (!popRect.width || !popRect.height) return;
+
+    const { left, top } = computePopoverPosition(
+        { width: popRect.width, height: popRect.height },
+        { x: mouseX, y: mouseY },
+        { width: window.innerWidth, height: window.innerHeight },
+    );
+
+    // setProperty is allowed; assigning to .style.left / .style.top is not.
+    hoverEl.style.setProperty("--em-popover-left", `${left}px`);
+    hoverEl.style.setProperty("--em-popover-top", `${top}px`);
+}

--- a/src/views/popovers/callout_citation_popover.tsx
+++ b/src/views/popovers/callout_citation_popover.tsx
@@ -13,6 +13,7 @@ import {
 import EquationCitator from "@/main";
 import Debugger from "@/debug/debugger";
 import { TargetElComponent } from "@/views/popovers/citation_popover";
+import { adjustPopoverPosition } from "@/utils/workspace/popoverPosition";
 import { RenderedCallout } from "@/services/callout_services";
 import { getLeafByElement } from "@/utils/workspace/workspace_utils";
 import { WidgetSizeManager } from "@/settings/styleManagers/widgetSizeManager";
@@ -26,7 +27,9 @@ export class CalloutCitationPopover extends HoverPopover {
     private readonly calloutsToRender: RenderedCallout[] = [];
     private readonly targetEl: HTMLElement;
     private readonly targetComponent: TargetElComponent;
-    
+    private readonly mouseX?: number;
+    private readonly mouseY?: number;
+
     constructor(
         private readonly plugin: EquationCitator,
         parent: HoverParent,
@@ -34,10 +37,18 @@ export class CalloutCitationPopover extends HoverPopover {
         private readonly prefix: string,  // e.g., "table:", "thm:", "def:"
         calloutsToRender: RenderedCallout[],
         private readonly sourcePath: string,
-        waitTime?: number
+        waitTime?: number,
+        mouseX?: number,
+        mouseY?: number
     ) {
         super(parent, targetEl, waitTime);
+        // Hide the whole host (Obsidian's .hover-popover box) from the very
+        // start — it has its own background/border and would flash at its
+        // default position while content renders and we reposition it.
+        this.hoverEl.addClass("em-popover-rendering");
         this.targetEl = targetEl;
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
         // Only render valid callouts (must have tag and content)
         this.calloutsToRender = calloutsToRender.filter(c =>
             c.tag && c.sourcePath && c.content
@@ -60,7 +71,12 @@ export class CalloutCitationPopover extends HoverPopover {
     }
 
     /**
-     * Display callouts in the popover
+     * Display callouts in the popover.
+     *
+     * The popover is rendered with `visibility: hidden` for the first frame so
+     * the user doesn't see content flicker while async callout markdown
+     * rendering finishes. Layout is performed while hidden, then
+     * `adjustPopoverPosition` measures the final size and we reveal it.
      */
     async showCallouts() {
         if (!this.targetEl) {
@@ -70,6 +86,9 @@ export class CalloutCitationPopover extends HoverPopover {
 
         const container: HTMLElement = this.hoverEl.createDiv();
         container.addClass("em-citation-popover-container", "em-callout-citation-popover-container", WidgetSizeManager.getCurrentClassName());
+        // Hide until the first render + position pass completes, so the
+        // user never sees an un-positioned or half-rendered popover.
+        container.addClass("em-popover-rendering");
 
         // Create header
         const header = container.createDiv();
@@ -109,7 +128,8 @@ export class CalloutCitationPopover extends HoverPopover {
         const leaf = getLeafByElement(this.plugin.app, this.targetEl);
         if (!leaf) return;
 
-        // Loop and create div for each callout
+        // Loop and create div for each callout (await so async rendering
+        // completes before we measure the popover for positioning)
         for (const callout of this.calloutsToRender) {
             const calloutOptionContainer = calloutsContainer.createDiv();
             calloutOptionContainer.addClass("em-callout-option-container");
@@ -131,6 +151,22 @@ export class CalloutCitationPopover extends HoverPopover {
             count: totalCallouts,
             displayName: displayName.toLowerCase(),
         });
+
+        // Position the popover AFTER all async rendering (callout markdown
+        // render) is done. Measuring before this point under-estimates the
+        // height and the viewport-clamp logic miscalculates, causing the
+        // popover to overflow. Position is computed from the recorded cursor
+        // position only.
+        if (this.mouseX !== undefined && this.mouseY !== undefined) {
+            adjustPopoverPosition(this.hoverEl, this.mouseX, this.mouseY);
+        }
+
+        // Show only after rendering + positioning are done. Both the CSS
+        // custom properties (position) and the visibility change are applied
+        // synchronously, so the browser paints the popover directly at its
+        // final position — no flash, no jump.
+        container.removeClass("em-popover-rendering");
+        this.hoverEl.removeClass("em-popover-rendering");
     }
 }
 

--- a/src/views/popovers/citation_popover.tsx
+++ b/src/views/popovers/citation_popover.tsx
@@ -1,7 +1,7 @@
 import EquationCitator from "@/main";
 import {
-    loadMathJax, 
-    Notice, 
+    loadMathJax,
+    Notice,
     WorkspaceLeaf,
     Component,
     HoverPopover,
@@ -12,6 +12,7 @@ import {
     finishRenderMath,
 } from "obsidian";
 import Debugger from "@/debug/debugger";
+import { adjustPopoverPosition } from "@/utils/workspace/popoverPosition";
 
 export class TargetElComponent extends Component {
     constructor(public targetEl: HTMLElement | null) {
@@ -28,35 +29,45 @@ import { copyEquationToClipboard } from "@/utils/misc/equation_copy";
 import { t } from "@/i18n/getLocale";
 
 /**
- * Citaton Popover Class, render the equations in the popover 
+ * Citation Popover Class, render the equations in the popover
  */
 export class CitationPopover extends HoverPopover {
     tags: string[] = []; // list of tags to be cited
     private readonly equationsToRender: RenderedEquation[] = [];
     private readonly targetEl: HTMLElement;
     private readonly targetComponent: TargetElComponent;
-    
+    private readonly mouseX?: number;
+    private readonly mouseY?: number;
+
     constructor(
         private readonly plugin: EquationCitator,
         parent: HoverParent,
         targetEl: HTMLElement,
         equationsToRender: RenderedEquation[],
         private readonly sourcePath: string,
-        waitTime?: number
+        waitTime?: number,
+        mouseX?: number,
+        mouseY?: number
     ) {
         super(parent, targetEl, waitTime);
+        // Hide the whole host (Obsidian's .hover-popover box) from the very
+        // start — it has its own background/border and would flash at its
+        // default position while content renders and we reposition it.
+        this.hoverEl.addClass("em-popover-rendering");
         this.targetEl = targetEl;
-        // only render valid equations 
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
+        // only render valid equations
         this.equationsToRender = equationsToRender.filter(eq => eq.tag && eq.md && eq.sourcePath);
         // Create targetComponent once to avoid memory leaks
         this.targetComponent = new TargetElComponent(this.targetEl);
     }
     public onOpen() { }
     public onClose(this: void): void { }
-    
+
     onload(): void {
         this.onOpen();
-        this.showEquations();
+        void this.showEquations();
     }
     onunload(): void {
         this.targetComponent.unload();
@@ -67,13 +78,16 @@ export class CitationPopover extends HoverPopover {
     * Warning: Never use show() method. It will overwrite original method
     * and cause unexpected render issues.
     */
-    showEquations() {
+    async showEquations() {
         if (!this.targetEl) {
             Debugger.log("can't find targetEl of citation popover");
             return;
         }
         const container: HTMLElement = this.hoverEl.createDiv();
         container.addClass("em-citation-popover-container", WidgetSizeManager.getCurrentClassName());
+        // Hide until the first render + position pass completes, so the
+        // user never sees an un-positioned or half-rendered popover.
+        container.addClass("em-popover-rendering");
 
         // Create header
         const header = container.createDiv();
@@ -84,7 +98,7 @@ export class CitationPopover extends HoverPopover {
         footerSpan.classList.add("em-citation-title-note");
         header.appendChild(footerSpan);
 
-        footerSpan.createDiv(); // placeholder  
+        footerSpan.createDiv(); // placeholder
         footerSpan.createDiv({
             text: t("popover.shiftScrollHint"),
             cls: "em-citation-title-note-text",
@@ -97,14 +111,14 @@ export class CitationPopover extends HoverPopover {
         const equationsContainer = content.createDiv();
         equationsContainer.addClass("em-equations-container");
 
-        // Loop and create div for each equation 
+        // Loop and create div for each equation
         const leaf = getLeafByElement(this.plugin.app, this.targetEl);
         if (!leaf) return;
-        this.equationsToRender.forEach((eq, index) => {
+        await Promise.all(this.equationsToRender.map((eq, index) => {
             const equationOptionContainer = equationsContainer.createDiv();
             equationOptionContainer.addClass("em-equation-option-container");
-            void renderEquationWrapper(this.plugin, leaf, eq, equationOptionContainer, this.targetComponent, true);
-        });
+            return renderEquationWrapper(this.plugin, leaf, eq, equationOptionContainer, this.targetComponent, true);
+        }));
 
         // Add footer with equation count
         const footer = container.createDiv();
@@ -113,17 +127,33 @@ export class CitationPopover extends HoverPopover {
         footer.textContent = totalEquations === 1 ?
             t("popover.equationCount.one") :
             t("popover.equationCount.many", { count: totalEquations });
+
+        // Position the popover AFTER all content (including async MathJax
+        // equation rendering) is in the DOM. Measuring before this point
+        // returns an under-estimated height and the viewport-clamp logic
+        // miscalculates, causing the popover to overflow vertically.
+        // Position is computed from the recorded cursor position only.
+        if (this.mouseX !== undefined && this.mouseY !== undefined) {
+            adjustPopoverPosition(this.hoverEl, this.mouseX, this.mouseY);
+        }
+
+        // Show only after rendering + positioning are done. Both the CSS
+        // custom properties (position) and the visibility change are applied
+        // synchronously, so the browser paints the popover directly at its
+        // final position — no flash, no jump.
+        container.removeClass("em-popover-rendering");
+        this.hoverEl.removeClass("em-popover-rendering");
     }
 }
 
 /**
  * Render the equation container (shared function by reading and live preview mode)
- * @param plugin 
- * @param leaf 
- * @param eq 
- * @param container 
- * @param targetComponent 
- * @param addLinkJump 
+ * @param plugin
+ * @param leaf
+ * @param eq
+ * @param container
+ * @param targetComponent
+ * @param addLinkJump
  */
 export async function renderEquationWrapper(
     plugin: EquationCitator,
@@ -159,7 +189,7 @@ export async function renderEquationWrapper(
     // Render the equation
     if (!window.MathJax) await loadMathJax();
     const eqTag = parseEquationTag(eq.md);
-    
+
     // render the math equation
     if (plugin.settings.useFastMathRenderer) {
         // Fast method: Direct conversion
@@ -169,7 +199,7 @@ export async function renderEquationWrapper(
         equationDiv.replaceChildren(rendered);
         await finishRenderMath();
     }
-    
+
     // Add click effects to each equation
     addClickEffects(equationWrapper);
     if (addLinkJump) {
@@ -229,7 +259,7 @@ function addContextMenuCopy(
     equationWrapper.addEventListener('contextmenu', (event: MouseEvent) => {
         event.preventDefault();
         const menu = new Menu();
-        
+
         menu.addItem((item) => {
             item.setTitle(t("context.copy"));
             item.setIcon("copy");
@@ -238,7 +268,7 @@ function addContextMenuCopy(
                 copyEquationToClipboard(contentWithTag, content, copyType);
             });
         });
-        
+
         menu.showAtMouseEvent(event);
     });
 }

--- a/src/views/popovers/figure_citation_popover.tsx
+++ b/src/views/popovers/figure_citation_popover.tsx
@@ -1,9 +1,9 @@
 import EquationCitator from "@/main";
 import {
-    WorkspaceLeaf, 
-    TFile, 
-    Notice, 
-    MarkdownView, 
+    WorkspaceLeaf,
+    TFile,
+    Notice,
+    MarkdownView,
     MarkdownRenderer,
     EditorRange,
     Component,
@@ -13,6 +13,7 @@ import {
 } from "obsidian";
 import Debugger from "@/debug/debugger";
 import { TargetElComponent } from "@/views/popovers/citation_popover";
+import { adjustPopoverPosition } from "@/utils/workspace/popoverPosition";
 import { RenderedFigure } from "@/services/figure_services";
 import { getLeafByElement } from "@/utils/workspace/workspace_utils";
 import { WidgetSizeManager } from "@/settings/styleManagers/widgetSizeManager";
@@ -32,6 +33,8 @@ export class FigureCitationPopover extends HoverPopover {
     private readonly figuresToRender: RenderedFigure[] = [];
     private readonly targetEl: HTMLElement;
     private readonly targetComponent: TargetElComponent;
+    private readonly mouseX?: number;
+    private readonly mouseY?: number;
 
     constructor(
         private readonly plugin: EquationCitator,
@@ -39,10 +42,18 @@ export class FigureCitationPopover extends HoverPopover {
         targetEl: HTMLElement,
         figuresToRender: RenderedFigure[],
         private readonly sourcePath: string,
-        waitTime?: number
+        waitTime?: number,
+        mouseX?: number,
+        mouseY?: number
     ) {
         super(parent, targetEl, waitTime);
+        // Hide the whole host (Obsidian's .hover-popover box) from the very
+        // start — it has its own background/border and would flash at its
+        // default position while content renders and we reposition it.
+        this.hoverEl.addClass("em-popover-rendering");
         this.targetEl = targetEl;
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
         // Only render valid figures (must have tag and either imagePath or imageLink)
         this.figuresToRender = figuresToRender.filter(fig =>
             fig.tag && fig.sourcePath && (fig.imagePath || fig.imageLink)
@@ -53,10 +64,10 @@ export class FigureCitationPopover extends HoverPopover {
 
     public onOpen() { }
     public onClose(this: void): void { }
-    
+
     onload(): void {
         this.onOpen();
-        this.showFigures();
+        void this.showFigures();
     }
 
     onunload(): void {
@@ -65,9 +76,15 @@ export class FigureCitationPopover extends HoverPopover {
     }
 
     /**
-     * Display figures in the popover
+     * Display figures in the popover.
+     *
+     * The popover is rendered with `visibility: hidden` for the first frame so
+     * the user doesn't see content flicker while async assets (MathJax
+     * equations, figure markdown rendering) finish loading. Layout is
+     * performed while hidden, then `adjustPopoverPosition` measures the
+     * final popover size and we reveal it.
      */
-    showFigures() {
+    async showFigures() {
         if (!this.targetEl) {
             Debugger.log("can't find targetEl of figure citation popover");
             return;
@@ -75,6 +92,9 @@ export class FigureCitationPopover extends HoverPopover {
 
         const container: HTMLElement = this.hoverEl.createDiv();
         container.addClass("em-citation-popover-container", "em-figure-citation-popover-container", WidgetSizeManager.getCurrentClassName());
+        // Hide until the first render + position pass completes, so the
+        // user never sees an un-positioned or half-rendered popover.
+        container.addClass("em-popover-rendering");
 
         // Create header
         const header = container.createDiv();
@@ -103,8 +123,9 @@ export class FigureCitationPopover extends HoverPopover {
         const leaf = getLeafByElement(this.plugin.app, this.targetEl);
         if (!leaf) return;
 
-        // Loop and create div for each figure
-        this.figuresToRender.forEach((fig, index) => {
+        // Loop and create div for each figure (for...of lets layout settle
+        // synchronously before we measure)
+        for (const fig of this.figuresToRender) {
             const figureOptionContainer = figuresContainer.createDiv();
             figureOptionContainer.addClass("em-figure-option-container");
             renderFigureWrapper(
@@ -115,7 +136,7 @@ export class FigureCitationPopover extends HoverPopover {
                 this.targetComponent,
                 true
             );
-        });
+        }
 
         // Add footer with figure count
         const footer = container.createDiv();
@@ -124,16 +145,30 @@ export class FigureCitationPopover extends HoverPopover {
         footer.textContent = t(totalFigures === 1 ? "popover.figureCount.one" : "popover.figureCount.many", {
             count: totalFigures,
         });
+
+        // Position the popover now that the sync DOM structure is complete
+        // and its size is measurable. Position is computed from the recorded
+        // cursor position only.
+        if (this.mouseX !== undefined && this.mouseY !== undefined) {
+            adjustPopoverPosition(this.hoverEl, this.mouseX, this.mouseY);
+        }
+
+        // Show only after rendering + positioning are done. Both the CSS
+        // custom properties (position) and the visibility change are applied
+        // synchronously, so the browser paints the popover directly at its
+        // final position — no flash, no jump.
+        container.removeClass("em-popover-rendering");
+        this.hoverEl.removeClass("em-popover-rendering");
     }
 }
 
 /**
  * Render a single figure wrapper with image and metadata
- * @remarks since there are 2 types of image formats (wiki link vs markdown link), 
+ * @remarks since there are 2 types of image formats (wiki link vs markdown link),
  *      the rendering logic is different for each type
  * @summary for `markdown link` (web image link), we always use image link to render the image;
  *      i.e., `<img src="imageLink" alt="title or tag">`
- * @summary for `wiki link` (internal image in obsidian vault), we need to resolve the vault path first, then render the image;   
+ * @summary for `wiki link` (internal image in obsidian vault), we need to resolve the vault path first, then render the image;
  */
 export function renderFigureWrapper(
     plugin: EquationCitator,

--- a/src/views/popovers/file_superscript_popover.tsx
+++ b/src/views/popovers/file_superscript_popover.tsx
@@ -1,18 +1,30 @@
 import { HoverParent, HoverPopover, TFile, normalizePath } from "obsidian";
 import Debugger from "@/debug/debugger";
+import { adjustPopoverPosition } from "@/utils/workspace/popoverPosition";
 import EquationCitator from "@/main";
 import { FootNote } from "@/utils/parsers/footnote_parser";
 
 export class FileSuperScriptPopover extends HoverPopover {
+    private readonly mouseX?: number;
+    private readonly mouseY?: number;
+
     constructor(
         private readonly plugin: EquationCitator,
         parent: HoverParent,
         private readonly targetEl: HTMLElement | null,
         private readonly sourcePath: string,
         private readonly footnoteIndex: string,
-        private readonly waitTime?: number
+        private readonly waitTime?: number,
+        mouseX?: number,
+        mouseY?: number
     ) {
         super(parent, targetEl, waitTime, null);
+        // Hide the whole host (Obsidian's .hover-popover box) from the very
+        // start — it has its own background/border and would flash at its
+        // default position while content renders and we reposition it.
+        this.hoverEl.addClass("em-popover-rendering");
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
     }
     onload(): void {
         void (async () => {
@@ -31,20 +43,27 @@ export class FileSuperScriptPopover extends HoverPopover {
             Debugger.error(`Failed to load footnotes for ${this.sourcePath}.`, error);
         })
     }
-    
+
     onunload() {
         // nothing to clean up
     }
 
+    /**
+     * Renders the footnote content. Popover is hidden for the first frame so
+     * the user doesn't see content flicker while the footnote DOM is built.
+     * After positioning completes we reveal it on the next frame.
+     */
     showFootnote(footnote: FootNote) {
         const container: HTMLElement = this.hoverEl.createDiv();
         container.addClass("em-file-superscript-popover-container");
+        // Hide until the first render + position pass completes.
+        container.addClass("em-popover-rendering");
 
         const footnoteContent: HTMLElement = container.createDiv();
         footnoteContent.addClass("em-file-superscript-popover-content");
 
         if (footnote.path !== null) {
-            // pure-file-link format footnote  
+            // pure-file-link format footnote
             const filePath: string = footnote.path;
             const normalizedSourcePath = normalizePath(this.sourcePath);
             const linkEl = footnoteContent.createEl("a", {
@@ -59,10 +78,10 @@ export class FileSuperScriptPopover extends HoverPopover {
                     Debugger.log("Invalid footnote file path: ", footnote.path);
                     return;
                 }
-                // open the file in current panel 
+                // open the file in current panel
                 const newLeaf = (evt.ctrlKey || evt.metaKey)   // Ctrl on Windows/Linux, Cmd on macOS
                     ? this.plugin.app.workspace.getLeaf("split", 'vertical') // split right by default
-                    : this.plugin.app.workspace.getLeaf(true); // reuse current 
+                    : this.plugin.app.workspace.getLeaf(true); // reuse current
 
                 this.plugin.app.workspace.setActiveLeaf(newLeaf, { focus: true });
                 this.plugin.app.workspace.openLinkText(
@@ -75,19 +94,34 @@ export class FileSuperScriptPopover extends HoverPopover {
             });
         }
         else if (footnote.url === null) {
-            // text-only format footnote  
+            // text-only format footnote
             const textEl = document.createElement("span");
             textEl.textContent = footnote.text;
             footnoteContent.appendChild(textEl);
             textEl.addClass("em-file-superscript-popover-text");
         }
         else {
-            // weblink format footnote 
+            // weblink format footnote
             const linkEl = footnoteContent.createEl("a", {
                 text: footnote.label ?? footnote.url,
             });
             linkEl.addClass("em-file-superscript-popover-link");
             linkEl.setAttr("href", footnote.url);
         }
+
+        // Position the popover AFTER all content is in the DOM. Measuring
+        // before content is appended under-estimates the height and the
+        // viewport-clamp logic miscalculates, causing overflow. Position is
+        // computed from the recorded cursor position only.
+        if (this.mouseX !== undefined && this.mouseY !== undefined) {
+            adjustPopoverPosition(this.hoverEl, this.mouseX, this.mouseY);
+        }
+
+        // Show only after rendering + positioning are done. Both the CSS
+        // custom properties (position) and the visibility change are applied
+        // synchronously, so the browser paints the popover directly at its
+        // final position — no flash, no jump.
+        container.removeClass("em-popover-rendering");
+        this.hoverEl.removeClass("em-popover-rendering");
     }
 }

--- a/src/views/widgets/callout_citation_render.tsx
+++ b/src/views/widgets/callout_citation_render.tsx
@@ -118,7 +118,9 @@ export function renderCalloutCitation(
                             fileSuperEl,
                             sourcePath,
                             crossFile,
-                            300
+                            300,
+                            e.clientX,
+                            e.clientY
                         );  
                     }
                 });
@@ -178,7 +180,9 @@ export function renderCalloutCitation(
                         prefix,
                         renderedCallouts,
                         sourcePath,
-                        300  // wait time in ms
+                        300,
+                        event.clientX,
+                        event.clientY
                     );
                 }
             })();  // ignore promise

--- a/src/views/widgets/callout_citation_widget.tsx
+++ b/src/views/widgets/callout_citation_widget.tsx
@@ -15,6 +15,8 @@ export class CalloutCitationWidget extends WidgetType {
     private el: HTMLElement| null = null;
     private view: EditorView | null = null;
     private popover: CalloutCitationPopover | null = null;
+    private lastMouseX: number | undefined;
+    private lastMouseY: number | undefined;
 
     constructor(
         private readonly plugin: EquationCitator,
@@ -77,6 +79,8 @@ export class CalloutCitationWidget extends WidgetType {
                     const ctrlKey = event.ctrlKey || event.metaKey;
                     if ((this.plugin.settings.requireCtrlForWidgetPreview && ctrlKey) ||
 						!this.plugin.settings.requireCtrlForWidgetPreview) {
+                        this.lastMouseX = event.clientX;
+                        this.lastMouseY = event.clientY;
                         void this.showPopover();
                     }
                 });
@@ -121,7 +125,9 @@ export class CalloutCitationWidget extends WidgetType {
             this.prefix,
             renderedCallouts,
             this.plugin.app.workspace.getActiveFile()?.path || "",
-            300
+            300,
+            this.lastMouseX,
+            this.lastMouseY
         );
 
         const popover = this.popover;

--- a/src/views/widgets/citation_render.tsx
+++ b/src/views/widgets/citation_render.tsx
@@ -492,7 +492,9 @@ async function showReadingModeFigurePopover(
         citationEl,
         figures,
         sourcePath,
-        300
+        300,
+        event.clientX,
+        event.clientY
     );
 
     popover.onClose = function () {
@@ -543,7 +545,9 @@ async function showReadingModeCalloutPopover(
         prefix,
         callouts,
         sourcePath,
-        300
+        300,
+        event.clientX,
+        event.clientY
     );
 
     popover.onClose = function () {
@@ -622,7 +626,9 @@ async function showReadingModePopover(
         citationEl,
         equations,
         sourcePath,
-        300);
+        300,
+        event.clientX,
+        event.clientY);
     popover.onClose = function () {
         popover = null;
     };

--- a/src/views/widgets/citation_widget.tsx
+++ b/src/views/widgets/citation_widget.tsx
@@ -20,6 +20,8 @@ export class CitationWidget extends WidgetType {
     private view: EditorView| null = null;
     private popover: CitationPopover | null = null;
     private readonly parent: HoverParent | null = null;
+    private lastMouseX: number | undefined;
+    private lastMouseY: number | undefined;
     constructor(
         private readonly plugin: EquationCitator,
         private readonly sourcePath: string,
@@ -76,6 +78,8 @@ export class CitationWidget extends WidgetType {
                     const ctrlKey = event.ctrlKey || event.metaKey;
                     if ((this.plugin.settings.requireCtrlForWidgetPreview && ctrlKey) ||
 						!this.plugin.settings.requireCtrlForWidgetPreview) {
+                        this.lastMouseX = event.clientX;
+                        this.lastMouseY = event.clientY;
                         void this.showPopover();
                     }
                 });
@@ -112,7 +116,9 @@ export class CitationWidget extends WidgetType {
             this.el,
             renderedEquations,
             this.plugin.app.workspace.getActiveFile()?.path || "",
-            300
+            300,
+            this.lastMouseX,
+            this.lastMouseY
         );
         const popover = this.popover;
         const originalOnClose = popover.onClose;
@@ -216,7 +222,9 @@ export function renderEquationCitation(
                             fileSuperEl,
                             sourcePath,
                             crossFile,
-                            300
+                            300,
+                            e.clientX,
+                            e.clientY
                         );
                     }
                 });

--- a/src/views/widgets/figure_citation_render.tsx
+++ b/src/views/widgets/figure_citation_render.tsx
@@ -116,7 +116,9 @@ export function renderFigureCitation(
                             fileSuperEl,
                             sourcePath,
                             crossFile,
-                            300
+                            300,
+                            e.clientX,
+                            e.clientY
                         );  
                     }
                 });
@@ -154,7 +156,7 @@ export function renderFigureCitation(
             if (isInteractive || ctrlKey) {
                 event.preventDefault();
                 event.stopPropagation();
-                void showFigurePopover(plugin, parent, el, citeFigureTags, sourcePath);
+                void showFigurePopover(plugin, parent, el, citeFigureTags, sourcePath, event.clientX, event.clientY);
             }
         });
     }
@@ -170,7 +172,9 @@ async function showFigurePopover(
     parent: HoverParent,
     targetEl: HTMLElement,
     figureTags: string[],
-    sourcePath: string
+    sourcePath: string,
+    mouseX?: number,
+    mouseY?: number
 ): Promise<void> {
     try {
         // Fetch figures from FigureServices
@@ -188,7 +192,9 @@ async function showFigurePopover(
             targetEl,
             figures,
             sourcePath,
-            300
+            300,
+            mouseX,
+            mouseY
         );
     } catch (error) {
         Debugger.error("Error showing figure popover:", error);

--- a/src/views/widgets/figure_citation_widget.tsx
+++ b/src/views/widgets/figure_citation_widget.tsx
@@ -15,6 +15,8 @@ export class FigureCitationWidget extends WidgetType {
     private el: HTMLElement|null = null;
     private view: EditorView| null = null;
     private popover: FigureCitationPopover | null = null;
+    private lastMouseX: number | undefined;
+    private lastMouseY: number | undefined;
 
     constructor(
         private readonly plugin: EquationCitator,
@@ -73,6 +75,8 @@ export class FigureCitationWidget extends WidgetType {
                     const ctrlKey = event.ctrlKey || event.metaKey;
                     if ((this.plugin.settings.requireCtrlForWidgetPreview && ctrlKey) ||
 						!this.plugin.settings.requireCtrlForWidgetPreview) {
+                        this.lastMouseX = event.clientX;
+                        this.lastMouseY = event.clientY;
                         void this.showPopover();
                     }
                 });
@@ -112,7 +116,9 @@ export class FigureCitationWidget extends WidgetType {
             this.el,
             renderedFigures,
             this.plugin.app.workspace.getActiveFile()?.path || "",
-            300
+            300,
+            this.lastMouseX,
+            this.lastMouseY
         );
 
         const popover = this.popover;


### PR DESCRIPTION
fix #97

## Summary by Sourcery

Add cursor-aware popover positioning and reveal popovers only after their content has been rendered and positioned.

New Features:
- Position citation, figure, callout, and footnote popovers relative to the cursor with viewport-aware horizontal and vertical flipping.

Bug Fixes:
- Prevent popovers from flashing at their default position or before asynchronous content has finished rendering.

Enhancements:
- Ensure popover dimensions are measured after content rendering and apply the final placement without overriding positioning through direct inline coordinates.